### PR TITLE
Realign variant variables

### DIFF
--- a/build/styles/ignition.css
+++ b/build/styles/ignition.css
@@ -730,7 +730,7 @@ sup {
   padding: 1rem 1.5rem;
   border-radius: 4px;
   color: #2e2e2e;
-  background-color: whitesmoke;
+  background-color: #f5f5f5;
 }
 
 .c-notice p:last-child {

--- a/source/settings/_color.scss
+++ b/source/settings/_color.scss
@@ -6,12 +6,12 @@
 
 // Provide a standard primary color.
 $color-primary-regular: #0056d6;
-// Provide lighter than standard primary colors.
+// Provide a set of light primary colors.
 $color-primary-light-a: change-color($color-primary-regular, $lightness: 96%);
 $color-primary-light-b: change-color($color-primary-regular, $lightness: 92%);
 $color-primary-light-c: change-color($color-primary-regular, $lightness: 88%);
 $color-primary-light-d: change-color($color-primary-regular, $lightness: 84%);
-// Provide darker than standard primary colors.
+// Provide a set of dark primary colors.
 $color-primary-dark-a: adjust-color($color-primary-regular, $lightness: -8%);
 $color-primary-dark-b: adjust-color($color-primary-regular, $lightness: -12%);
 
@@ -19,12 +19,12 @@ $color-primary-dark-b: adjust-color($color-primary-regular, $lightness: -12%);
 
 // Provide a standard negative color.
 $color-negative-regular: #ad0c00;
-// Provide lighter than standard negative colors.
+// Provide a set of light negative colors.
 $color-negative-light-a: change-color($color-negative-regular, $lightness: 96%);
 $color-negative-light-b: change-color($color-negative-regular, $lightness: 92%);
 $color-negative-light-c: change-color($color-negative-regular, $lightness: 88%);
 $color-negative-light-d: change-color($color-negative-regular, $lightness: 84%);
-// Provide darker than standard negative colors.
+// Provide a set of dark negative colors.
 $color-negative-dark-a: adjust-color($color-negative-regular, $lightness: -8%);
 $color-negative-dark-b: adjust-color($color-negative-regular, $lightness: -12%);
 
@@ -32,13 +32,13 @@ $color-negative-dark-b: adjust-color($color-negative-regular, $lightness: -12%);
 
 // Provide a standard gray color.
 $color-gray-regular: #2e2e2e;
-// Provide lighter than standard gray colors.
+// Provide a set of light gray colors.
 $color-gray-light-a: change-color($color-gray-regular, $lightness: 96%);
 $color-gray-light-b: change-color($color-gray-regular, $lightness: 92%);
 $color-gray-light-c: change-color($color-gray-regular, $lightness: 88%);
 $color-gray-light-d: change-color($color-gray-regular, $lightness: 84%);
 $color-gray-light-e: change-color($color-gray-regular, $lightness: 80%);
-// Provide darker than standard gray colors.
+// Provide a set of dark gray colors.
 $color-gray-dark-a: adjust-color($color-gray-regular, $lightness: -8%);
 $color-gray-dark-b: adjust-color($color-gray-regular, $lightness: -12%);
 
@@ -46,7 +46,7 @@ $color-gray-dark-b: adjust-color($color-gray-regular, $lightness: -12%);
 
 // Provide a standard white color.
 $color-white-regular: #fff;
-// Provide transparent white colors.
+// Provide a set of transparent white colors.
 $color-white-transparent-a: change-color($color-white-regular, $alpha: 0.84);
 $color-white-transparent-b: change-color($color-white-regular, $alpha: 0.76);
 $color-white-transparent-c: change-color($color-white-regular, $alpha: 0.32);

--- a/source/settings/_color.scss
+++ b/source/settings/_color.scss
@@ -7,48 +7,48 @@
 // Provide a standard primary color.
 $color-primary-regular: #0056d6;
 // Provide a set of light primary colors.
-$color-primary-light-a: change-color($color-primary-regular, $lightness: 96%);
-$color-primary-light-b: change-color($color-primary-regular, $lightness: 92%);
-$color-primary-light-c: change-color($color-primary-regular, $lightness: 88%);
-$color-primary-light-d: change-color($color-primary-regular, $lightness: 84%);
+$color-primary-light-a: #ebf3ff;
+$color-primary-light-b: #d6e7ff;
+$color-primary-light-c: #c2daff;
+$color-primary-light-d: #adceff;
 // Provide a set of dark primary colors.
-$color-primary-dark-a: adjust-color($color-primary-regular, $lightness: -8%);
-$color-primary-dark-b: adjust-color($color-primary-regular, $lightness: -12%);
+$color-primary-dark-a: #0046ad;
+$color-primary-dark-b: #003d99;
 
 // Negative
 
 // Provide a standard negative color.
 $color-negative-regular: #ad0c00;
 // Provide a set of light negative colors.
-$color-negative-light-a: change-color($color-negative-regular, $lightness: 96%);
-$color-negative-light-b: change-color($color-negative-regular, $lightness: 92%);
-$color-negative-light-c: change-color($color-negative-regular, $lightness: 88%);
-$color-negative-light-d: change-color($color-negative-regular, $lightness: 84%);
+$color-negative-light-a: #ffeceb;
+$color-negative-light-b: #ffd9d6;
+$color-negative-light-c: #ffc6c2;
+$color-negative-light-d: #ffb3ad;
 // Provide a set of dark negative colors.
-$color-negative-dark-a: adjust-color($color-negative-regular, $lightness: -8%);
-$color-negative-dark-b: adjust-color($color-negative-regular, $lightness: -12%);
+$color-negative-dark-a: #840900;
+$color-negative-dark-b: #700800;
 
 // Gray
 
 // Provide a standard gray color.
 $color-gray-regular: #2e2e2e;
 // Provide a set of light gray colors.
-$color-gray-light-a: change-color($color-gray-regular, $lightness: 96%);
-$color-gray-light-b: change-color($color-gray-regular, $lightness: 92%);
-$color-gray-light-c: change-color($color-gray-regular, $lightness: 88%);
-$color-gray-light-d: change-color($color-gray-regular, $lightness: 84%);
-$color-gray-light-e: change-color($color-gray-regular, $lightness: 80%);
+$color-gray-light-a: #f5f5f5;
+$color-gray-light-b: #ebebeb;
+$color-gray-light-c: #e0e0e0;
+$color-gray-light-d: #d6d6d6;
+$color-gray-light-e: #cccccc;
 // Provide a set of dark gray colors.
-$color-gray-dark-a: adjust-color($color-gray-regular, $lightness: -8%);
-$color-gray-dark-b: adjust-color($color-gray-regular, $lightness: -12%);
+$color-gray-dark-a: #1a1a1a;
+$color-gray-dark-b: #0f0f0f;
 
 // White
 
 // Provide a standard white color.
 $color-white-regular: #fff;
 // Provide a set of transparent white colors.
-$color-white-transparent-a: change-color($color-white-regular, $alpha: 0.84);
-$color-white-transparent-b: change-color($color-white-regular, $alpha: 0.76);
-$color-white-transparent-c: change-color($color-white-regular, $alpha: 0.32);
-$color-white-transparent-d: change-color($color-white-regular, $alpha: 0.24);
-$color-white-transparent-e: change-color($color-white-regular, $alpha: 0.16);
+$color-white-transparent-a: rgba(255, 255, 255, 0.84);
+$color-white-transparent-b: rgba(255, 255, 255, 0.76);
+$color-white-transparent-c: rgba(255, 255, 255, 0.32);
+$color-white-transparent-d: rgba(255, 255, 255, 0.24);
+$color-white-transparent-e: rgba(255, 255, 255, 0.16);

--- a/source/settings/_decoration.scss
+++ b/source/settings/_decoration.scss
@@ -12,8 +12,8 @@ $opacity-medium: 0.5;
 // Provide a standard border width.
 $border-width-regular: 1px;
 // Provide a set of thick border widths.
-$border-width-thick-a: 4 * $border-width-regular;
-$border-width-thick-b: 2 * $border-width-regular;
+$border-width-thick-a: 4px;
+$border-width-thick-b: 2px;
 
 // Border radius
 

--- a/source/settings/_decoration.scss
+++ b/source/settings/_decoration.scss
@@ -11,7 +11,7 @@ $opacity-medium: 0.5;
 
 // Provide a standard border width.
 $border-width-regular: 1px;
-// Provide thicker than standard border widths.
+// Provide a set of thick border widths.
 $border-width-thick-a: 4 * $border-width-regular;
 $border-width-thick-b: 2 * $border-width-regular;
 

--- a/source/settings/_spacing.scss
+++ b/source/settings/_spacing.scss
@@ -6,13 +6,13 @@
 
 // Provide a standard space value.
 $space-regular: 1rem;
-// Provide larger than standard space values.
+// Provide a set of large space values.
 $space-large-a: 4 * $space-regular;
 $space-large-b: 3 * $space-regular;
 $space-large-c: 2 * $space-regular;
 $space-large-d: 1.5 * $space-regular;
 $space-large-e: 1.25 * $space-regular;
-// Provide smaller than standard space values.
+// Provide a set of small space values.
 $space-small-a: 0.75 * $space-regular;
 $space-small-b: 0.625 * $space-regular;
 $space-small-c: 0.5 * $space-regular;

--- a/source/settings/_spacing.scss
+++ b/source/settings/_spacing.scss
@@ -7,14 +7,14 @@
 // Provide a standard space value.
 $space-regular: 1rem;
 // Provide a set of large space values.
-$space-large-a: 4 * $space-regular;
-$space-large-b: 3 * $space-regular;
-$space-large-c: 2 * $space-regular;
-$space-large-d: 1.5 * $space-regular;
-$space-large-e: 1.25 * $space-regular;
+$space-large-a: 4rem;
+$space-large-b: 3rem;
+$space-large-c: 2rem;
+$space-large-d: 1.5rem;
+$space-large-e: 1.25rem;
 // Provide a set of small space values.
-$space-small-a: 0.75 * $space-regular;
-$space-small-b: 0.625 * $space-regular;
-$space-small-c: 0.5 * $space-regular;
-$space-small-d: 0.375 * $space-regular;
-$space-small-e: 0.25 * $space-regular;
+$space-small-a: 0.75rem;
+$space-small-b: 0.625rem;
+$space-small-c: 0.5rem;
+$space-small-d: 0.375rem;
+$space-small-e: 0.25rem;

--- a/source/settings/_typography.scss
+++ b/source/settings/_typography.scss
@@ -20,11 +20,11 @@ $root-font-size: 100%;
 // Provide a standard font size.
 $font-size-regular: 1rem;
 // Provide a set of large font sizes.
-$font-size-large-a: 3 * $font-size-regular;
-$font-size-large-b: 2 * $font-size-regular;
-$font-size-large-c: 1.5 * $font-size-regular;
-$font-size-large-d: 1.3125 * $font-size-regular;
-$font-size-large-e: 1.125 * $font-size-regular;
+$font-size-large-a: 3rem;
+$font-size-large-b: 2rem;
+$font-size-large-c: 1.5rem;
+$font-size-large-d: 1.3125rem;
+$font-size-large-e: 1.125rem;
 
 // Line height
 

--- a/source/settings/_typography.scss
+++ b/source/settings/_typography.scss
@@ -19,7 +19,7 @@ $font-family-mono: SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace
 $root-font-size: 100%;
 // Provide a standard font size.
 $font-size-regular: 1rem;
-// Provide larger than standard font sizes.
+// Provide a set of large font sizes.
 $font-size-large-a: 3 * $font-size-regular;
 $font-size-large-b: 2 * $font-size-regular;
 $font-size-large-c: 1.5 * $font-size-regular;
@@ -30,7 +30,7 @@ $font-size-large-e: 1.125 * $font-size-regular;
 
 // Provide a standard line height.
 $line-height-regular: 1.5;
-// Provide smaller than standard line heights.
+// Provide a set of small line heights.
 $line-height-small-a: 1.33333333;
 $line-height-small-b: 1.25;
 $line-height-small-c: 1.16666666;


### PR DESCRIPTION
Naming color variations based on their relation to regular colors could be problematic because the latter may have very low or high lightness. This will lead to variations that are designated as light or dark even though they aren't.

Similar problems may arise with variables that define border width or line height.